### PR TITLE
refact(bash_profile): Replace deprecated GREP_OPTIONS with aliases

### DIFF
--- a/bash_profile--RBENV
+++ b/bash_profile--RBENV
@@ -62,8 +62,12 @@ export LSCOLORS=ExGxFxdxCxDxDxaccxaeex
 # Force ls to use colors (G) and use humanized file sizes (h)
 alias ls='ls -Gh'
 
-# Force grep to always use the color option and show line numbers
-export GREP_OPTIONS='--color=always'
+# Force grep to output in color unless the output is piped or redirected to a
+# file (--color=auto) and display number lines (n)
+alias grep="grep --color=auto -n"
+# grep variant that always outputs in color (--color=always) and displays
+# number lines (n)
+alias grepc="grep --color=always -n"
 
 # Set sublime as the default editor
 which -s subl && export EDITOR="subl --wait"

--- a/bash_profile--RVM
+++ b/bash_profile--RVM
@@ -67,6 +67,13 @@ export LSCOLORS=ExGxFxdxCxDxDxaccxaeex
 # Force ls to use colors (G) and use humanized file sizes (h)
 alias ls='ls -Gh'
 
+# Force grep to output in color unless the output is piped or redirected to a
+# file (--color=auto) and display number lines (n)
+alias grep="grep --color=auto -n"
+# grep variant that always outputs in color (--color=always) and displays
+# number lines (n)
+alias grepc="grep --color=always -n"
+
 # Set sublime as the default editor
 which -s subl && export EDITOR="subl --wait"
 


### PR DESCRIPTION
#### Commit Message
- Remove export GREP_OPTIONS='--color=always'
  - GREP_OPTIONS is now deprecated and should be replaced by an alias or script
- Add alias grep="grep --color=auto -n" to replace GREP_OPTIONS
  - Cons of using --color=always
    - If the grep output is piped (e.g `| less`) without using the `-R` or
      `--RAW-CONTROL-CHARS` parameter, the output will contain control characters
      instead of coloration
    - If the grep output is being redirected to another file
      (e.g `> hunters-playhouse.txt`), the output file will contain control
      characters instead of coloration
  - Cons of using --color=auto
    - If the grep output is piped being redirected to another file, the output
      will not contain coloration
- Add alias grepc="grep --color=always -n" as a variant grep
- Add `-n` flag to display line numbers
#### Plain English

`GREP_OPTIONS` is deprecated, so it should be replaced.  `GREP_OPTIONS='--color=always'` is synonymous with `alias grep="grep --color=always"`.  This works great, but I prefer to set the color to _auto_ instead of _always_.

Setting the color to _always_ will output display control characters instead of actual color if you pipe the output (unless you use `-R`) or redirect the output to another file, like in the example below.

``` sh
## INPUT:
grep --color=always stfu ~/.bash_profile | less
## OUTPUT:
alias ESC[01;31mstfuESC[00m="osascript -e \"set volume output muted true\"; echo \"Sound is muted\"; echo"
```

Setting the color to _auto_ will not display color if you pipe or redirect the output, but you won't have to deal with those pesky control characters appearing.

``` sh
## INPUT:
grep --color=auto stfu ~/.bash_profile | less
## OUTPUT:
alias stfu="osascript -e \"set volume output muted true\"; echo \"Sound is muted\"; echo"
```

My personal solution is to use `alias grep="grep --color=auto -n"` and create the variant I call "grep color", `alias grepc="grep --color=always -n"`.

Oh yeah, the `-n` flag just displays number lines in the output, which I find helpful.
